### PR TITLE
build: remove unnecessary ${SRC} variable from CMakeLists.txt

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Debug ULF_COMExamples",
       "type": "cppdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/build/examples/ULF_COMExamples",
+      "program": "${workspaceFolder}/build/examples/basics/ULF_COMExamples",
       "args": [],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,34 +2,28 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "CMake ULF_COMTests Clang",
-      "type": "shell",
-      "isBackground": true,
-      "command": "cmake -Bbuild -GNinja -DCMAKE_TOOLCHAIN_FILE=CMakeModules/src/toolchains/clang.cmake -DCMAKE_BUILD_TYPE=Debug"
-    },
-    {
-      "label": "CMake ULF_COMTests",
-      "type": "shell",
-      "isBackground": true,
-      "command": "cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug"
-    },
-    {
-      "label": "Ninja ULF_COMTests",
+      "label": "Build ULF_COMTests",
       "type": "shell",
       "isBackground": true,
       "command": "ninja -C build ULF_COMTests"
     },
     {
-      "label": "Run ULF_COMTests",
+      "label": "Config ULF_COMTests",
       "type": "shell",
       "isBackground": true,
-      "command": "./build/tests/ULF_COMTests"
+      "command": "cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug"
     },
     {
       "label": "Run PlantUML",
       "type": "shell",
       "isBackground": true,
       "command": "plantuml -o ./images ./data/operating_modes.pu"
+    },
+    {
+      "label": "Run ULF_COMTests",
+      "type": "shell",
+      "isBackground": true,
+      "command": "./build/tests/ULF_COMTests"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 0.0.2
+- Bugfix `SRC` variable passed in `add_library`
+
 ## 0.0.1
 - Initial release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(ULF_COM_MAX_VERSION_LEN
     32uz
     CACHE STRING "Maximum length of version string")
 
-add_library(ULF_COM INTERFACE ${SRC})
+add_library(ULF_COM INTERFACE)
 add_library(ULF::COM ALIAS ULF_COM)
 
 target_compile_features(ULF_COM INTERFACE cxx_std_23)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,30 @@ cmake --build build --target ULF_COMExamples
 ```
 
 ## Usage
-To check whether a string contains an MX1 binary protocol frame or a command, the two functions `str2mx1bin` or `str2cmd` can be used. Both functions expect that the searched schema is at the beginning of the string. In order to be able to distinguish between an error case and the case where the data is still incomplete, the return value of both functions is `std::expected<std::optional<std::string_view>, std::errc>`. If the pattern is not recognized at all, i.e. in the event of an error, then a `std::errc` is returned. If something is found but the data is not yet complete, a `std::nullopt` is returned. Otherwise the found data is returned as `std::string_view`. The following snippet shows how `str2mx1bin` can be used.
+To check whether a string contains an MX1 binary protocol frame or a command, the two functions `str2mx1bin` or `str2cmd` can be used. Both functions expect that the searched schema is at the beginning of the string. In order to be able to distinguish between an error case and the case where the data is still incomplete, the return value of both functions is `std::expected<std::optional<std::string_view>, std::errc>`. If the pattern is not recognized at all, i.e. in the event of an error, then a `std::errc` is returned. If something is found but the data is not yet complete, a `std::nullopt` is returned. Otherwise the found data is returned as `std::string_view`. The following snippet shows how `str2cmd` can be used.
+```cpp
+// Check if character stream contains valid command
+auto maybe_cmd{ulf::com::str2cmd("DCC_EIN\r and then some")};
+
+// Could be command
+if (maybe_cmd) {
+  // Already complete?
+  if (*maybe_cmd) {
+    // Complete command
+    auto cmd{**maybe_cmd};
+    std::cout << cmd << "\n";
+  }
+  // No, still missing characters
+  else {}
+}
+// Error, not command
+else {}
+
+// Or, more concise
+if (maybe_cmd == "DCC_EIN\r"sv) std::cout << "Command found\n";
+```
+
+And the same pattern can also be applied to `str2mx1bin`.
 ```cpp
 // Check if character stream contains valid MX1 binary
 auto maybe_mx1bin{ulf::com::str2mx1bin("\x01\x01"
@@ -84,6 +107,7 @@ if (maybe_mx1bin) {
   if (*maybe_mx1bin) {
     // Complete MX1 binary
     auto mx1bin{**maybe_mx1bin};
+    std::cout << mx1bin << "\n";
   }
   // No, still missing characters
   else {}

--- a/examples/basics/main.cpp
+++ b/examples/basics/main.cpp
@@ -1,4 +1,29 @@
+#include <iostream>
 #include <ulf/com.hpp>
+
+using namespace std::literals;
+
+void str2cmd() {
+  // Check if character stream contains valid command
+  auto maybe_cmd{ulf::com::str2cmd("DCC_EIN\r and then some")};
+
+  // Could be command
+  if (maybe_cmd) {
+    // Already complete?
+    if (*maybe_cmd) {
+      // Complete command
+      auto cmd{**maybe_cmd};
+      std::cout << cmd << "\n";
+    }
+    // No, still missing characters
+    else {}
+  }
+  // Error, not command
+  else {}
+
+  // Or, more concise
+  if (maybe_cmd == "DCC_EIN\r"sv) std::cout << "Command found\n";
+}
 
 void str2mx1bin() {
   // Check if character stream contains valid MX1 binary
@@ -11,6 +36,7 @@ void str2mx1bin() {
     if (*maybe_mx1bin) {
       // Complete MX1 binary
       auto mx1bin{**maybe_mx1bin};
+      std::cout << mx1bin << "\n";
     }
     // No, still missing characters
     else {}
@@ -26,6 +52,7 @@ void ping() {
 }
 
 int main() {
+  str2cmd();
   str2mx1bin();
   ping();
 }

--- a/tests/com/str2cmd.cpp
+++ b/tests/com/str2cmd.cpp
@@ -4,9 +4,17 @@
 TEST(str2cmd, string_empty) { EXPECT_TRUE(ulf::com::str2cmd("")); }
 
 TEST(str2cmd, string_invalid) {
-  auto b{ulf::com::str2cmd("123")};
-  EXPECT_FALSE(b);
-  EXPECT_EQ(b, std::unexpected(std::errc::invalid_argument));
+  {
+    auto b{ulf::com::str2cmd("123")};
+    EXPECT_FALSE(b);
+    EXPECT_EQ(b, std::unexpected(std::errc::invalid_argument));
+  }
+
+  {
+    auto b{ulf::com::str2cmd("\rDCC_")};
+    EXPECT_FALSE(b);
+    EXPECT_EQ(b, std::unexpected(std::errc::invalid_argument));
+  }
 }
 
 TEST(str2cmd, string_too_short) {


### PR DESCRIPTION
The `CMakeLists.txt` file contains an unnecessary variable

```cmake
add_library(ULF_COM INTERFACE ${SRC})
```